### PR TITLE
README: Link to successor repo, prominently

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,15 @@
 Numpy Windows wheel builder
 ###########################
 
-**No longer maintained. This is the wrong repo, do not use it.**
+No longer maintained
+~~~~~~~~~~~~~~~~~~~~
+
+**This is the wrong repo, do not use it.**
+
+numpy Windows wheel builds were migrated to https://github.com/MacPython/numpy-wheels
+
+Original README (archived)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Build numpy wheels with MSVC and pre-built ATLAS binaries.
 


### PR DESCRIPTION
The PR I would, but can't, file in numpy/windows-wheel-builder since it's already been archived.

While I realize numpy/windows-wheel-builder#6 was already closed as addressed, the deprecation message in the README still struck me as less-than-overpoweringly-dominant in the README, which is really what you'd want. Worse, even though the README said "you're in the wrong place", there was no link to https://github.com/MacPython/numpy-wheels (aka the **right** place) _anywhere_ in the README, so one had to track down the issue in order to be pointed at the logical next place to look. That information should be far more obvious, like so.

Effectively reopens, then fixes numpy/windows-wheel-builder#6 

cc: @mattip @rgommers @matthew-brett

(Sorry, the actual target repo is read-only now that it's archived, so I can't open a PR there. But I really do feel that it's worth updating the README and/or the repo description to more prominently direct people where they **should** go, rather than just saying "You're in the wrong place" and leaving them hanging.)
